### PR TITLE
Refactor the `Hero.svelte` component and bump dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "ygdir-demo",
-  "version": "1.0.0",
+  "name": "ygdir-documentation",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -659,9 +659,9 @@
       }
     },
     "@babel/plugin-transform-runtime": {
-      "version": "7.7.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.7.5.tgz",
-      "integrity": "sha512-X+w9wJRzOoAPBfTEcFJisVppQ8OTQMxrVgmi7ZLVWehqVd8ciHN09A1XjB91Iw+Sgf77Y9Oy7CfxKNr1tVkK7g==",
+      "version": "7.7.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.7.6.tgz",
+      "integrity": "sha512-tajQY+YmXR7JjTwRvwL4HePqoL3DYxpYXIHKVvrOIvJmeHe2y1w4tz5qz9ObUDC9m76rCzIMPyn4eERuwA4a4A==",
       "dev": true,
       "requires": {
         "@babel/helper-module-imports": "^7.7.4",
@@ -728,9 +728,9 @@
       }
     },
     "@babel/preset-env": {
-      "version": "7.7.5",
-      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.7.5.tgz",
-      "integrity": "sha512-wDPbiaZdGzsJuTWlpLHJxmwslwHGLZ8F5v69zX3oAWeTOFWdy4OJHoTKg26oAnFg052v+/LAPY5os9KB0LrOEA==",
+      "version": "7.7.6",
+      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.7.6.tgz",
+      "integrity": "sha512-k5hO17iF/Q7tR9Jv8PdNBZWYW6RofxhnxKjBMc0nG4JTaWvOTiPoO/RLFwAKcA4FpmuBFm6jkoqaRJLGi0zdaQ==",
       "dev": true,
       "requires": {
         "@babel/helper-module-imports": "^7.7.4",
@@ -787,9 +787,9 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.7.5",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.5.tgz",
-      "integrity": "sha512-UXhClKWTL7/vlYX49kETXti6VbpPJK/pdsIOqUMhUUES/lqThpNTsmC/0aU/IW4uozDUx17axjeqel7SCYF6EQ==",
+      "version": "7.7.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.6.tgz",
+      "integrity": "sha512-BWAJxpNVa0QlE5gZdWjSxXtemZyZ9RmrmVozxt3NUXeZhVIJ5ANyqmMc0JDrivBZyxUuQvFxlvH4OWWOogGfUw==",
       "dev": true,
       "requires": {
         "regenerator-runtime": "^0.13.2"
@@ -1260,12 +1260,12 @@
       }
     },
     "core-js-compat": {
-      "version": "3.4.7",
-      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.4.7.tgz",
-      "integrity": "sha512-57+mgz/P/xsGdjwQYkwtBZR3LuISaxD1dEwVDtbk8xJMqAmwqaxLOvnNT7kdJ7jYE/NjNptyzXi+IQFMi/2fCw==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.5.0.tgz",
+      "integrity": "sha512-E7iJB72svRjJTnm9HDvujzNVMCm3ZcDYEedkJ/sDTNsy/0yooCd9Cg7GSzE7b4e0LfIkjijdB1tqg0pGwxWeWg==",
       "dev": true,
       "requires": {
-        "browserslist": "^4.8.0",
+        "browserslist": "^4.8.2",
         "semver": "^6.3.0"
       },
       "dependencies": {
@@ -2704,9 +2704,9 @@
       "dev": true
     },
     "regjsparser": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.6.0.tgz",
-      "integrity": "sha512-RQ7YyokLiQBomUJuUG8iGVvkgOLxwyZM8k6d3q5SAXpg4r5TZJZigKFvC6PpD+qQ98bCDC5YelPeA3EucDoNeQ==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.6.1.tgz",
+      "integrity": "sha512-7LutE94sz/NKSYegK+/4E77+8DipxF+Qn2Tmu362AcmsF2NYq/wx3+ObvU90TKEhjf7hQoFXo23ajjrXP7eUgg==",
       "dev": true,
       "requires": {
         "jsesc": "~0.5.0"
@@ -2800,9 +2800,9 @@
       }
     },
     "rollup": {
-      "version": "1.27.8",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.27.8.tgz",
-      "integrity": "sha512-EVoEV5rAWl+5clnGznt1KY8PeVkzVQh/R0d2s3gHEkN7gfoyC4JmvIVuCtPbYE8NM5Ep/g+nAmvKXBjzaqTsHA==",
+      "version": "1.27.12",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.27.12.tgz",
+      "integrity": "sha512-51iR7n6NQfdQJlRrIktaGmkdt395A8Vue7CdnlrK6UhY9DY2GaKsTdljWeXisJuZh+w90Gz8VFNh5X+yxP20oQ==",
       "dev": true,
       "requires": {
         "@types/estree": "*",
@@ -2858,15 +2858,16 @@
       }
     },
     "rollup-plugin-terser": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-terser/-/rollup-plugin-terser-4.0.4.tgz",
-      "integrity": "sha512-wPANT5XKVJJ8RDUN0+wIr7UPd0lIXBo4UdJ59VmlPCtlFsE20AM+14pe+tk7YunCsWEiuzkDBY3QIkSCjtrPXg==",
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-terser/-/rollup-plugin-terser-5.1.3.tgz",
+      "integrity": "sha512-FuFuXE5QUJ7snyxHLPp/0LFXJhdomKlIx/aK7Tg88Yubsx/UU/lmInoJafXJ4jwVVNcORJ1wRUC5T9cy5yk0wA==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
-        "jest-worker": "^24.0.0",
-        "serialize-javascript": "^1.6.1",
-        "terser": "^3.14.1"
+        "jest-worker": "^24.6.0",
+        "rollup-pluginutils": "^2.8.1",
+        "serialize-javascript": "^2.1.2",
+        "terser": "^4.1.0"
       }
     },
     "rollup-pluginutils": {
@@ -2942,9 +2943,9 @@
       "dev": true
     },
     "serialize-javascript": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.9.1.tgz",
-      "integrity": "sha512-0Vb/54WJ6k5v8sSWN09S0ora+Hnr+cX40r9F170nT+mSkaxltoE/7R3OrIdBSUv1OoiobH1QoWQbCnAO+e8J1A==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-2.1.2.tgz",
+      "integrity": "sha512-rs9OggEUF0V4jUSecXazOYsLfu7OGK2qIn3c7IPBiffz32XniEp/TX9Xmc9LQfK2nQ2QKHvZ2oygKUGU0lG4jQ==",
       "dev": true
     },
     "set-blocking": {
@@ -3181,9 +3182,9 @@
       }
     },
     "svelte": {
-      "version": "3.16.0",
-      "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.16.0.tgz",
-      "integrity": "sha512-k7nCQTd9/rGOi25iv/sBeJe2W89hK2lcaUsmUQqikH0Tye7Gh/tvvF9LuNTSF+dQY/isNX+g8K9fJf+5jMLfxw==",
+      "version": "3.16.4",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.16.4.tgz",
+      "integrity": "sha512-+9k0fWp6q2AW0Niap+AIjERoRV9ZTj2yr+33JtjYHAxFRwTGdsy6UYnNThyrUNZPBHdlnbTuEt2V8p07jJGiZQ==",
       "dev": true
     },
     "svelte-preprocess": {
@@ -3207,9 +3208,9 @@
       }
     },
     "svelte-typewriter": {
-      "version": "1.5.3",
-      "resolved": "https://registry.npmjs.org/svelte-typewriter/-/svelte-typewriter-1.5.3.tgz",
-      "integrity": "sha512-18Rs/2X/PBNiI1fId80sZ6bEtOAQXK87sV6+9xIwv/e9mMBj8eFiSEA5Nsbl+K0RE7PWQ5qLSB/uW3Eotk2M4Q==",
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/svelte-typewriter/-/svelte-typewriter-1.5.4.tgz",
+      "integrity": "sha512-eIkLCMzNBDdNx+D3W6rN39mHzhA46KGkZR9lfDezCU1VcqiCCW26gA2ryrVSlxDkWMzJYVprORMxOT8h7s2H1Q==",
       "dev": true
     },
     "tar": {
@@ -3224,14 +3225,14 @@
       }
     },
     "terser": {
-      "version": "3.17.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-3.17.0.tgz",
-      "integrity": "sha512-/FQzzPJmCpjAH9Xvk2paiWrFq+5M6aVOf+2KRbwhByISDX/EujxsK+BAvrhb6H+2rtrLCHK9N01wO014vrIwVQ==",
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-4.4.2.tgz",
+      "integrity": "sha512-Uufrsvhj9O1ikwgITGsZ5EZS6qPokUOkCegS7fYOdGTv+OA90vndUbU6PEjr5ePqHfNUbGyMO7xyIZv2MhsALQ==",
       "dev": true,
       "requires": {
-        "commander": "^2.19.0",
+        "commander": "^2.20.0",
         "source-map": "~0.6.1",
-        "source-map-support": "~0.5.10"
+        "source-map-support": "~0.5.12"
       },
       "dependencies": {
         "source-map": {

--- a/package.json
+++ b/package.json
@@ -12,30 +12,30 @@
     "test": "run-p --race dev cy:run"
   },
   "dependencies": {
-    "compression": "^1.7.1",
+    "compression": "^1.7.4",
     "polka": "next",
-    "sirv": "^0.4.0"
+    "sirv": "^0.4.2"
   },
   "devDependencies": {
-    "@babel/core": "^7.0.0",
-    "@babel/plugin-syntax-dynamic-import": "^7.0.0",
-    "@babel/plugin-transform-runtime": "^7.0.0",
-    "@babel/preset-env": "^7.0.0",
-    "@babel/runtime": "^7.0.0",
-    "@rollup/plugin-replace": "^2.2.0",
+    "@babel/core": "^7.7.5",
+    "@babel/plugin-syntax-dynamic-import": "^7.7.4",
+    "@babel/plugin-transform-runtime": "^7.7.6",
+    "@babel/preset-env": "^7.7.6",
+    "@babel/runtime": "^7.7.6",
+    "@rollup/plugin-replace": "^2.2.1",
     "autoprefixer": "^9.7.3",
     "node-sass": "^4.13.0",
     "npm-run-all": "^4.1.5",
-    "rollup": "^1.12.0",
-    "rollup-plugin-babel": "^4.0.2",
-    "rollup-plugin-commonjs": "^10.0.0",
+    "rollup": "^1.27.12",
+    "rollup-plugin-babel": "^4.3.3",
+    "rollup-plugin-commonjs": "^10.1.0",
     "rollup-plugin-node-resolve": "^5.2.0",
-    "rollup-plugin-svelte": "^5.0.1",
-    "rollup-plugin-terser": "^4.0.4",
-    "sapper": "^0.27.0",
-    "svelte": "^3.0.0",
+    "rollup-plugin-svelte": "^5.1.1",
+    "rollup-plugin-terser": "^5.1.3",
+    "sapper": "^0.27.9",
+    "svelte": "^3.16.4",
     "svelte-preprocess": "^3.2.6",
-    "svelte-typewriter": "^1.5.3",
+    "svelte-typewriter": "^1.5.4",
     "ygdir": "^1.16.0"
   }
 }

--- a/src/components/Hero.svelte
+++ b/src/components/Hero.svelte
@@ -1,7 +1,6 @@
 <script>
-    import Typewriter from 'svelte-typewriter'
+    import typewriter from 'svelte-typewriter/typewriter'
 </script>
-
 
 <style>
     p {
@@ -20,6 +19,4 @@
     }
 </style>
 
-<Typewriter cascade>
-<p>Ygdir is a new CSS framework that aims to make CSS less painful.</p>
-</Typewriter>
+<p use:typewriter>Ygdir is a new CSS framework that aims to make CSS less painful.</p>


### PR DESCRIPTION
Greetings, maintainer of [`svete-typewriter`](https://github.com/henriquehbr/svelte-typewriter) here

### Refactor `Hero.svete`

Replace the `<Typewriter cascade>` component that has been previously used to animated the headline of the `Hero.svelte` component for the `use:typewriter` directive, by opting for the directive-based approach (with a single paragraph of text on it) you don't need to pass the `cascade` option, and also, you can make use of a much more cleaner syntax

### Bump dependencies on `package.json`

And also, npm was complaining about a vulnerability on the package `serialize-package` (which is a dependency of `rollup-plugin-terser`), so i updated the entire dependency tree on `package.json`, including a major bump from `^4.0.4` to `^5.1.3` that was required in order to fix the vulnerability on `rollup-plugin-terser`